### PR TITLE
fix: Warning spawned by BoxPasswordStrengthDisplay

### DIFF
--- a/src/components/box-password-strength-display.js
+++ b/src/components/box-password-strength-display.js
@@ -60,7 +60,7 @@ class BoxPasswordStrengthDisplay extends Component {
             }
             return (
               <View
-                key={label.label}
+                key={`${index}-${label.label}`}
                 style={[style.boxContainer,
                   boxContainerStyle,
                   { backgroundColor: boxColor, width: levelWidth, marginHorizontal: boxSpacing },


### PR DESCRIPTION
Fix the problem that was generating the warning "Warning:
Each child in an array or iterator should have a unique "key" prop"
from BoxPasswordStrengthDisplay component (at box-password-strength-display.js:62)