### PR TITLE
fix: Level key reference at BoxPasswordStrengthDisplay

### DIFF
--- a/src/components/box-password-strength-display.js
+++ b/src/components/box-password-strength-display.js
@@ -60,7 +60,7 @@ class BoxPasswordStrengthDisplay extends Component {
             }
             return (
               <View
-                key={label.label}
+                key={level.label}
                 style={[style.boxContainer,
                   boxContainerStyle,
                   { backgroundColor: boxColor, width: levelWidth, marginHorizontal: boxSpacing },


### PR DESCRIPTION
There was a small mistake at BoxPasswordStrengthDisplay line 63, instead of "label.label" it should be "level.label",and because of this the component was showing a warning when used.