### PR TITLE
[Bug Fix] Using Native Driver for Animations

### DIFF
--- a/src/components/bar-password-strength-display.js
+++ b/src/components/bar-password-strength-display.js
@@ -43,6 +43,7 @@ class BarPasswordStrengthDisplay extends Component {
     Animated.timing(this.animatedBarWidth, {
       toValue: absoluteWidth,
       duration: 700,
+      useNativeDriver: false,
     }).start();
     return (
       <View style={[style.wrapper, wrapperStyle]}>

--- a/src/components/box-password-strength-display.js
+++ b/src/components/box-password-strength-display.js
@@ -51,11 +51,13 @@ class BoxPasswordStrengthDisplay extends Component {
               Animated.timing(currentAnimatedBoxWidth, {
                 toValue: levelWidth,
                 duration: 700,
+                useNativeDriver: false,
               }).start();
             } else {
               Animated.timing(currentAnimatedBoxWidth, {
                 toValue: 0,
                 duration: 700,
+                useNativeDriver: false,
               }).start();
             }
             return (


### PR DESCRIPTION
Closes #12

**Warning Message Display:**
warn: Animated: useNativeDriver was not specified. This is a required 'option and must be explicitly set to true or false

**Implemented Fix:**
Found the useNativeDriver settings in the Animated.timing docs and in this PR I set that to no use the Native Driver. That fixed the warning for me in my expo app.